### PR TITLE
Hide loading on accounts with no cloud storage accounts

### DIFF
--- a/divvy/cloudfilebrowser.js
+++ b/divvy/cloudfilebrowser.js
@@ -135,9 +135,6 @@ var provision = (function() {
      var _provision = {
         getTokenForElement: function(element) {
             var eleObj = CloudElements.getConfig()[element];
-
-            console.log(eleObj);
-
             return eleObj['elementToken'];
         },
 
@@ -755,12 +752,7 @@ var cloudFileBrowser = (function() {
                 'element' : element
             };
 
-            // Manually validate token before calling isAuthorized?
-            token = _provision.getTokenForElement(element);
-            CloudElements.validateToken(token);
-
             if (provision.isAuthorized(element)) {
-                console.log('provision isAuthorized');
                 cloudFileBrowser.showLoading();
                 provision.createInstance(element, cloudFileBrowser.handleOnProvision, callbackArgs);
             }

--- a/divvy/cloudfilebrowser.js
+++ b/divvy/cloudfilebrowser.js
@@ -135,6 +135,9 @@ var provision = (function() {
      var _provision = {
         getTokenForElement: function(element) {
             var eleObj = CloudElements.getConfig()[element];
+
+            console.log(eleObj);
+
             return eleObj['elementToken'];
         },
 
@@ -752,7 +755,12 @@ var cloudFileBrowser = (function() {
                 'element' : element
             };
 
+            // Manually validate token before calling isAuthorized?
+            token = _provision.getTokenForElement(element);
+            CloudElements.validateToken(token);
+
             if (provision.isAuthorized(element)) {
+                console.log('provision isAuthorized');
                 cloudFileBrowser.showLoading();
                 provision.createInstance(element, cloudFileBrowser.handleOnProvision, callbackArgs);
             }

--- a/divvy/cloudfilebrowser.js
+++ b/divvy/cloudfilebrowser.js
@@ -726,8 +726,6 @@ var cloudFileBrowser = (function() {
         },
 
         buildTabs: function() {
-            $('#services-tabs').addClass('disable-element');
-
             // Inspect services object, and build a tab + trigger
             // for each service installed
 


### PR DESCRIPTION
This PR removes the code that was disabling services tabs in the cloud storage modal even when no cloud storage services were connected.

JIRA Ticket: https://divvyhq.atlassian.net/browse/DIV-7860